### PR TITLE
setting the body to nil forces the connection to close and ignore keep-alive settings

### DIFF
--- a/libs/weblit-server.lua
+++ b/libs/weblit-server.lua
@@ -116,7 +116,9 @@ local function newServer(run)
       if upgrade then
         return upgrade(read, write, updateDecoder, updateEncoder, socket)
       end
-      write(body)
+      if body then
+        write(body)
+      end
       if not (res.keepAlive and head.keepAlive) then
         break
       end


### PR DESCRIPTION
weblit-auto-headers sets the body to nil on head requests and when the etag matches. Those requests cause the connection to close prematurely, and there is no reason to do so.
