### PR TITLE
Add Cookie Middleware

### DIFF
--- a/libs/weblit-cookie.lua
+++ b/libs/weblit-cookie.lua
@@ -1,35 +1,33 @@
-return function(secret)
-  return function (req, res, go)
-    local cookies = {}
-    for i = 1, #req.headers do
-      local key, value = unpack(req.headers[i])
-      if key:lower() == "cookie" then
-        for k, v in value:gmatch("([^ ;=]+)=([^;=]+)") do
-          cookies[k] = v
-        end
+return function (req, res, go)
+  local cookies = {}
+  for i = 1, #req.headers do
+    local key, value = unpack(req.headers[i])
+    if key:lower() == "cookie" then
+      for k, v in value:gmatch("([^ ;=]+)=([^;=]+)") do
+        cookies[k] = v
       end
     end
-    req.cookies = cookies
-    function res.setCookie(key, value, props)
-      cookies[key] = value
-      local cookie = key .. "=" .. value
-      if type(props) == 'table' then
-        for k, v in pairs(props) do
-          cookie = cookie .. "; " .. k .. '=' .. v
-        end
-      end
-      res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
-    end
-    function res.clearCookie(key, props)
-      -- set the cookie blank
-      local cookie = key .. "=null"
-      local props = props or {}
-      props.Expires = "Thu, 01 Jan 1970 00:00:00 GMT"
+  end
+  req.cookies = cookies
+  function res.setCookie(key, value, props)
+    cookies[key] = value
+    local cookie = key .. "=" .. value
+    if type(props) == 'table' then
       for k, v in pairs(props) do
         cookie = cookie .. "; " .. k .. '=' .. v
       end
-      res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
     end
-    return go()
+    res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
   end
+  function res.clearCookie(key, props)
+    -- set the cookie blank
+    local cookie = key .. "=null"
+    local props = props or {}
+    props.Expires = "Thu, 01 Jan 1970 00:00:00 GMT"
+    for k, v in pairs(props) do
+      cookie = cookie .. "; " .. k .. '=' .. v
+    end
+    res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
+  end
+  return go()
 end

--- a/libs/weblit-cookie.lua
+++ b/libs/weblit-cookie.lua
@@ -21,7 +21,6 @@ return function(secret)
       res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
     end
     function res.clearCookie(key, props)
-      req.cookies[key] = nil
       -- set the cookie blank
       local cookie = key .. "=null"
       local props = props or {}

--- a/libs/weblit-cookie.lua
+++ b/libs/weblit-cookie.lua
@@ -1,0 +1,36 @@
+return function(secret)
+  return function (req, res, go)
+    local cookies = {}
+    for i = 1, #req.headers do
+      local key, value = unpack(req.headers[i])
+      if key:lower() == "cookie" then
+        for k, v in value:gmatch("([^ ;=]+)=([^;=]+)") do
+          cookies[k] = v
+        end
+      end
+    end
+    req.cookies = cookies
+    function res.setCookie(key, value, props)
+      cookies[key] = value
+      local cookie = key .. "=" .. value
+      if type(props) == 'table' then
+        for k, v in pairs(props) do
+          cookie = cookie .. "; " .. k .. '=' .. v
+        end
+      end
+      res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
+    end
+    function res.clearCookie(key, props)
+      req.cookies[key] = nil
+      -- set the cookie blank
+      local cookie = key .. "=null"
+      local props = props or {}
+      props.Expires = "Thu, 01 Jan 1970 00:00:00 GMT"
+      for k, v in pairs(props) do
+        cookie = cookie .. "; " .. k .. '=' .. v
+      end
+      res.headers[#res.headers + 1] = {"Set-Cookie", cookie}
+    end
+    return go()
+  end
+end


### PR DESCRIPTION
I saw that there was a simple cookie middleware in the luvit-quest repo, so I migrated part of it to weblit to be available as a default middleware.

to start it, just `use` the lib

``` lua
.use(require('weblit-cookie'))
```

Then you can set and clear cookies

``` lua
function handlerSetCookie(req, res)
  res.code = 200
  res.setCookie("cookie-key", "cookie-value", { Path = "/" })
end

function handlerRemoveCookie(req, res)
  res.code = 200
  res.clearCookie("cookie-key", { Path = "/" })
end
```

The lib would probably need to be improved a little more to normalize key names when setting properties on the cookies, as well as checking to see the properties are valid for a `Set Cookie` response header.
