### PR TITLE
Fix markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ while also listening on port `8443` using HTTPS.
 The `host` option defaults to `"127.0.0.1"`.  The default port depends on if
 you're running as root and if the connection is TLS encrypted.
 
-      | Root | User
-------|-----:|------:
-HTTP  | 80   | 8080
-HTTPS | 442  | 8443
+|      | Root | User
+|------|-----:|------:
+|HTTP  | 80   | 8080
+|HTTPS | 442  | 8443
 
 
 ### use(middleware)


### PR DESCRIPTION
This wasn't rendered properly because the first column's empty header made the formatting ambiguous.