### PR TITLE
Moved a misplaced parenthesis that made a condition always true

### DIFF
--- a/libs/weblit-app.lua
+++ b/libs/weblit-app.lua
@@ -27,7 +27,7 @@ local server = require('weblit-server').newServer(router.run)
 -- Forward router methods from app instance
 local serverMeta = {}
 function serverMeta:__index(name)
-  if type(router[name] == "function") then
+  if type(router[name]) == "function" then
     return function(...)
       router[name](...)
       return self


### PR DESCRIPTION
Rather than checking if the type of a thing was function, the code checked the type of the result of equality between the thing and the string function. The type of the result of the equality is always boolean, and the string of that is truthy, so the guard clause never triggers, so rather than proxying just functions, it proxies everything as a function.